### PR TITLE
Use AV_CPU_FLAG_MMXEXT

### DIFF
--- a/libpostproc/postprocess.c
+++ b/libpostproc/postprocess.c
@@ -961,7 +961,7 @@ static int get_cpu_caps(int cpuCaps)
 
         if (caps & AV_CPU_FLAG_MMX)
             cpuCaps |= PP_CPU_CAPS_MMX;
-        if (caps & AV_CPU_FLAG_MMX2)
+        if (caps & AV_CPU_FLAG_MMXEXT)
             cpuCaps |= PP_CPU_CAPS_MMX2;
         if (caps & AV_CPU_FLAG_3DNOW)
             cpuCaps |= PP_CPU_CAPS_3DNOW;


### PR DESCRIPTION
Buiding on Gentoo Linux fails with:

```
error: ‘AV_CPU_FLAG_MMX2’ undeclared (first use in this function)
         if (caps & AV_CPU_FLAG_MMX2)
                    ^~~~~~~~~~~~~~~~
```
ffmpeg/libav has replaced AV_CPU_FLAG_MMX2 with AV_CPU_FLAG_MMXEXT.

See https://github.com/FFmpeg/FFmpeg/commit/08bd8c8ab37e56bf567a8081fed820d12b05d153 and [libav@bf7114b](https://git.libav.org/?p=libav.git;a=commit;h=bf7114b6caad8cf94696b0299c13b0d26bf291be) and [Bug-621172](https://bugs.gentoo.org/621172).